### PR TITLE
Dont use whols instead use print dir

### DIFF
--- a/src/dataAPI/jupyter/PythonExecutor.ts
+++ b/src/dataAPI/jupyter/PythonExecutor.ts
@@ -177,7 +177,7 @@ export class PythonPandasExecutor {
 
     public async getVariableNames(): Promise<string[]> {
         try {
-            const code = '%who_ls'; // python magic command
+            const code = 'print(dir())'
             const res = await this.executeCode(code);
             const content = res['content'];
             const data = content.join("").replace(/'/g, '"');


### PR DESCRIPTION
## Functionality

- Replace calls to `%who_ls` with `print(dir())` to get variables in memory
- Who ls doesnt show variables with underscore at beginning like `_mydf` and also doesnt interact well with pretty printers like rich where the string is formatted

## Issues addressed

Fixes #87 
