### PR TITLE
show all vis by default in compact view

### DIFF
--- a/src/components/ColumnProfile.svelte
+++ b/src/components/ColumnProfile.svelte
@@ -35,8 +35,6 @@
     export let view: string = 'summaries'; // summaries, example
     export let containerWidth: number;
     export let hideRight = false;
-    // hide the null percentage number
-    export let hideNullPercentage = false;
 
     // locals
     let active = false;
@@ -53,7 +51,6 @@
         containerWidth > config.compactBreakpoint
             ? formatInteger
             : formatCompactInteger;
-    $: hideNullPercentage = containerWidth < config.compactBreakpoint;
 </script>
 
 <!-- pl-10 -->
@@ -116,10 +113,7 @@
                 {/if}
             </div>
 
-            <div
-                style:width="{config.nullPercentageWidth}px"
-                class:hidden={hideNullPercentage}
-            >
+            <div style:width="{config.nullPercentageWidth}px">
                 <!-- Number of nulls -->
                 {#if totalRows !== 0 && totalRows !== undefined && nullCount !== undefined}
                     <Tooltip location="right" alignment="center" distance={8}>

--- a/src/components/utils/sizes.ts
+++ b/src/components/utils/sizes.ts
@@ -6,9 +6,8 @@ export const config = {
     // width of null %
     nullPercentageWidth: 75,
     mediumCutoff: 300,
-    compactBreakpoint: 370,
+    compactBreakpoint: 350,
     largeBreakpoint: 500,
-    hideRight: 325,
     summaryVizWidth: { default: 120, large: 240 },
     exampleWidth: { medium: 204, small: 132 }
 };

--- a/src/components/viz/TopKSummary.svelte
+++ b/src/components/viz/TopKSummary.svelte
@@ -41,17 +41,13 @@
                 : formatPercentage(count / totalRows)}
             <div>
                 <BarAndLabel value={count / totalRows} {color}>
-                    <span
-                        class:text-gray-500={negligiblePercentage &&
-                            containerWidth >= config.hideRight}
-                    >
+                    <span class:text-gray-500={negligiblePercentage}>
                         {formatCount(count)}
-                        {#if !containerWidth || containerWidth >= config.hideRight}
-                            {#if percentage.length < 6}&nbsp;{/if}{#if percentage.length < 5}&nbsp;{/if}&nbsp;<span
-                                class:text-gray-600={!negligiblePercentage}
-                                >({percentage})</span
-                            >
-                        {/if}
+
+                        {#if percentage.length < 6}&nbsp;{/if}{#if percentage.length < 5}&nbsp;{/if}&nbsp;<span
+                            class:text-gray-600={!negligiblePercentage}
+                            >({percentage})</span
+                        >
                     </span>
                 </BarAndLabel>
             </div>


### PR DESCRIPTION
## Functionality

- show all vis in default width compact view, was hiding null charts and percentages in categorical vars but now can see

## Issues addressed

Fixes #82 
