### PR TITLE
only update when AP is open

### DIFF
--- a/src/ProfilePanel.ts
+++ b/src/ProfilePanel.ts
@@ -49,7 +49,7 @@ export class ProfilePanel extends StackedPanel {
 
     public async connectNotebook(notebook: NotebookAPI) {
         this.session = notebook.panel.sessionContext;
-        await this._profileModel.connectNotebook(notebook);
+        await this._profileModel.connectNotebook(notebook, () => { return this.isVisible });
     }
 
     // ~~~~~~~~~ Lifecycle methods for closing panel ~~~~~~~~~
@@ -62,4 +62,15 @@ export class ProfilePanel extends StackedPanel {
         super.onCloseRequest(msg);
         this.dispose();
     }
+
+    /**
+     * Called before the widget is made visible.
+     * other useful state messages are onAfterShow, 
+     * onBeforeHide, onAfterHide.
+     * @param msg 
+     */
+    protected onBeforeShow(msg: Message): void {
+        this._profileModel.updateAll();
+    }
+
 }

--- a/src/dataAPI/ProfileModel.ts
+++ b/src/dataAPI/ProfileModel.ts
@@ -83,8 +83,8 @@ export class ProfileModel {
         this._logger = logger
     }
 
-    public async connectNotebook(notebook: NotebookAPI) {
-        console.log('Connecting notebook to ProfilePanel');
+    public async connectNotebook(notebook: NotebookAPI, widgetIsVisible: () => boolean) {
+        // console.log('Connecting notebook to ProfilePanel');
         this._notebook = notebook;
         this.executor.setSession(notebook.panel.sessionContext);
         this.resetData();
@@ -97,7 +97,9 @@ export class ProfileModel {
         this._notebook.changed.connect((sender, value) => {
             // when cell is run, update data
             if (value === 'cell run') {
-                this.updateRootData();
+                if (widgetIsVisible()) {
+                    this.updateRootData();
+                }
             }
 
             if (value == "name") {
@@ -105,7 +107,9 @@ export class ProfileModel {
             }
 
             if (value == "activeCell") {
-                this.handleCellSelect()
+                if (widgetIsVisible()) {
+                    this.handleCellSelect()
+                }
             }
         });
         this.listenForRestart();
@@ -130,6 +134,14 @@ export class ProfileModel {
         if (this.notebook) {
             this.notebook.addCell(kind, text);
         }
+    }
+
+    /** 
+     * Called when widget is shown, updating root data may not always be necessary
+    **/
+    public updateAll() {
+        this.updateRootData()
+        this.handleCellSelect()
     }
 
     public async updateRootData() {


### PR DESCRIPTION
## Functionality
- Only updates the data in AP if the panel is actually visible; does not slow down notebook if the panel is closed

## Issues addressed

Fixes #124 